### PR TITLE
Added AWS region selection.

### DIFF
--- a/src/aws.h
+++ b/src/aws.h
@@ -52,6 +52,7 @@ struct aws_handle {
 	int dynamo_https;
 	int dynamo_port;
 	char *dynamo_host;
+	char *dynamo_region;
 
 };
 

--- a/src/aws_dynamo.c
+++ b/src/aws_dynamo.c
@@ -844,15 +844,23 @@ void aws_dynamo_set_https_certificate_file(struct aws_handle *aws, const char *f
 	http_set_https_certificate_file(aws->http, filename);
 }
 
-int aws_dynamo_set_endpoint(struct aws_handle *aws, const char *host) {
-	char *h;
+int aws_dynamo_set_endpoint(struct aws_handle *aws, const char *host, const char *region) {
+	char *h, *r;
 
 	h = strdup(host);
 	if (h == NULL) {
 		Warnx("aws_dynamo_set_endpoint: failed ot allocate host");
 		return -1;
-	}	
+	}
+	r = strdup(region);
+	if (r == NULL)
+	{
+		Warnx("aws_dynamo_set_endpoint: failed ot allocate region");
+		free(h);
+		return -1;
+	}
 	aws->dynamo_host = h;
+	aws->dynamo_region = r;
 	return 0;
 }
 

--- a/src/aws_dynamo.h
+++ b/src/aws_dynamo.h
@@ -26,6 +26,7 @@ extern "C" {
 #endif
 
 #define AWS_DYNAMO_DEFAULT_HOST "dynamodb.us-east-1.amazonaws.com"
+#define AWS_DYNAMO_DEFAULT_REGION "us-east-1"
 
 /* AWS DynamoDB HTTP headers names.  These are all lowercase
 	to simplify the signature calculation. */
@@ -260,6 +261,7 @@ void aws_dynamo_set_https_certificate_file(struct aws_handle *aws, const char *c
  * aws_dynamo_set_endpoint() - Set the endpoint to use for DynamoDB requests.
  * @aws:	Library handle.
  * @host:	Endpoint hostname (ex. 'dynamodb.us-west-2.amazonaws.com').
+ * @region:	Endpoint region (ex. 'us-east-1').
  *
  * The endpoint is the host to use for DynamoDB requests.  See the list
  * of supported endpoints here:
@@ -270,7 +272,7 @@ void aws_dynamo_set_https_certificate_file(struct aws_handle *aws, const char *c
  *
  * Return: 0 on success, -1 on failure to allocate a copy of @host.
  */
-int aws_dynamo_set_endpoint(struct aws_handle *aws, const char *host);
+int aws_dynamo_set_endpoint(struct aws_handle *aws, const char *host, const char *region);
 
 /**
  * aws_dynamo_set_port() - Set the TCP port to use for DynamoDB requests.


### PR DESCRIPTION
DynamoDB region was hardcoded and I was not able to use aws_dynamo with DynamoDB instance that was started in non default region. Security error was appeared.
I added ability to chose region where DynamoDB started in the aws_dynamo_set_endpoint function.